### PR TITLE
Add functionality to validate data section only

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -334,12 +334,7 @@ def parse(
     with_tree=True,
     with_header=False,
     only_header=False,
-    validate_data_only=False
 ):
-    if validate_data_only: # Used by the Validation Service to validate only the data section of an IFC file, ignoring the header.
-        only_header = False
-        with_header = False
-        with_tree= False
     if filename:
         assert not filecontent
         filecontent = builtins.open(filename, encoding=None).read()
@@ -412,20 +407,8 @@ def parse(
 
         NT = type("NullTransformer", (Transformer,), methods)
         transformer = {"transformer": NT()}
-        
-    if validate_data_only:
-        match = re.search(
-            r"DATA\s*;(.*?)ENDSEC\s*;",
-            filecontent_wo_comments,
-            flags=re.DOTALL | re.IGNORECASE,
-        )
-        if not match:
-            raise ValidationError("No DATA section found in file")
-        filecontent_wo_comments = f"DATA;{match.group(1)}ENDSEC;"
-        start_rule = "data_section"
-    else:# Parse entire file (header + data)
-        start_rule = "file"
-    parser = Lark(grammar, parser="lalr", start=start_rule, **transformer)
+
+    parser = Lark(grammar, parser="lalr", start="file", **transformer)
 
     try:
         ast = parser.parse(filecontent_wo_comments)

--- a/__main__.py
+++ b/__main__.py
@@ -11,9 +11,6 @@ def main():
     parser.add_argument("--only-header", action="store_true", help="Validate only the header section.")
     
     args = parser.parse_args()
-    if args.only_header:
-        print("Cannot use both --only-header and --only-data at the same time", file=sys.stderr)
-        sys.exit(2)
         
     try:
         parse(

--- a/__main__.py
+++ b/__main__.py
@@ -6,16 +6,33 @@ if __name__ == "__main__":
     args = [x for x in sys.argv[1:] if not x.startswith("-")]
     flags = [x for x in sys.argv[1:] if x.startswith("-")]
 
-    fn = args[0]
+    filename = args[0]
     start_time = time.time()
+    
+    with_progress = "--progress" in flags
+    json_output = "--json" in flags
+    only_header = "--header-only" in flags
+    validate_data_only = "--data-only" in flags
+    
+    
+    # Sanity check: can't use both at once
+    if only_header and validate_data_only:
+        print("Cannot use both --header-only and --data-only at the same time", file=sys.stderr)
+        sys.exit(2)
 
     try:
-        parse(filename=fn, with_progress="--progress" in flags, with_tree=False)
-        if "--json" not in flags:
+        parse(
+            filename=filename,
+            with_progress=with_progress,
+            with_tree=False,
+            only_header=only_header,
+            validate_data_only=validate_data_only,
+        )
+        if not json_output:
             print("Valid", file=sys.stderr)
         exit(0)
     except ValidationError as exc:
-        if "--json" not in flags:
+        if not json_output:
             print(exc, file=sys.stderr)
         else:
             import sys

--- a/__main__.py
+++ b/__main__.py
@@ -1,42 +1,38 @@
 import sys
-import time
+import json
+import argparse
 from . import parse, ValidationError
 
-if __name__ == "__main__":
-    args = [x for x in sys.argv[1:] if not x.startswith("-")]
-    flags = [x for x in sys.argv[1:] if x.startswith("-")]
-
-    filename = args[0]
-    start_time = time.time()
+def main():
+    parser = argparse.ArgumentParser(description="Parse and validate STEP file.")
+    parser.add_argument("filename", help="The STEP file to validate.")
+    parser.add_argument("--progress", action="store_true", help="Show progress during validation.")
+    parser.add_argument("--json", action="store_true", help="Output errors in JSON format.")
+    parser.add_argument("--only-header", action="store_true", help="Validate only the header section.")
+    parser.add_argument("--only-data", action="store_true", help="Validate only the data section.")
     
-    with_progress = "--progress" in flags
-    json_output = "--json" in flags
-    only_header = "--header-only" in flags
-    validate_data_only = "--data-only" in flags
-    
-    
-    # Sanity check: can't use both at once
-    if only_header and validate_data_only:
-        print("Cannot use both --header-only and --data-only at the same time", file=sys.stderr)
+    args = parser.parse_args()
+    if args.only_header and args.only_data:
+        print("Cannot use both --only-header and --only-data at the same time", file=sys.stderr)
         sys.exit(2)
-
+        
     try:
         parse(
-            filename=filename,
-            with_progress=with_progress,
-            with_tree=False,
-            only_header=only_header,
-            validate_data_only=validate_data_only,
+            filename=args.filename,
+            with_progress = args.progress,
+            with_tree = False,
+            only_header=args.only_header,
+            validate_data_only = args.only_data
         )
-        if not json_output:
+        if not args.json:
             print("Valid", file=sys.stderr)
         exit(0)
     except ValidationError as exc:
-        if not json_output:
+        if not args.json:
             print(exc, file=sys.stderr)
         else:
-            import sys
-            import json
-
             json.dump(exc.asdict(), sys.stdout)
         exit(1)
+
+if __name__ == '__main__':
+    main()    

--- a/__main__.py
+++ b/__main__.py
@@ -11,7 +11,7 @@ def main():
     parser.add_argument("--only-header", action="store_true", help="Validate only the header section.")
     
     args = parser.parse_args()
-    if args.only_header and args.only_data:
+    if args.only_header:
         print("Cannot use both --only-header and --only-data at the same time", file=sys.stderr)
         sys.exit(2)
         

--- a/__main__.py
+++ b/__main__.py
@@ -9,7 +9,6 @@ def main():
     parser.add_argument("--progress", action="store_true", help="Show progress during validation.")
     parser.add_argument("--json", action="store_true", help="Output errors in JSON format.")
     parser.add_argument("--only-header", action="store_true", help="Validate only the header section.")
-    parser.add_argument("--only-data", action="store_true", help="Validate only the data section.")
     
     args = parser.parse_args()
     if args.only_header and args.only_data:
@@ -22,7 +21,6 @@ def main():
             with_progress = args.progress,
             with_tree = False,
             only_header=args.only_header,
-            validate_data_only = args.only_data
         )
         if not args.json:
             print("Valid", file=sys.stderr)

--- a/test_parser.py
+++ b/test_parser.py
@@ -126,23 +126,3 @@ def test_valid_headers(filename):
     # error in body; with_header should not raise an error
     with nullcontext():
         parse(filename=filename, with_tree=False, only_header=True, with_header=True)
-        
-
-@pytest.mark.parametrize("filename", [
-    'fixtures/fail_invalid_header_entity.ifc',
-    'fixtures/fail_no_header.ifc',
-])
-def test_invalid_headers_(filename):
-    # error in header; validate_data_only should not raise an error
-    with nullcontext():
-        parse(filename=filename, validate_data_only=True)
-
-@pytest.mark.parametrize("filename", [
-    'fixtures/fail_duplicate_id.ifc',
-    'fixtures/fail_double_comma.ifc',
-    'fixtures/fail_double_semi.ifc'
-])
-def test_valid_headers(filename):
-    # error in body; validate_data_only should raise an error
-    with pytest.raises(ValidationError):
-        parse(filename=filename, validate_data_only=True)

--- a/test_parser.py
+++ b/test_parser.py
@@ -106,3 +106,43 @@ def test_file_mvd_attr():
     assert len(f.mvd.comments) == 2
     assert all(v in vars(f.header).keys() for v in ['file_description', 'file_name', 'file_schema'])
     assert len(f.header.file_name) == 7
+
+
+@pytest.mark.parametrize("filename", [
+    'fixtures/fail_invalid_header_entity.ifc',
+    'fixtures/fail_no_header.ifc',
+])
+def test_invalid_headers_(filename):
+    # error in header; with_header should raise an error
+    with pytest.raises(ValidationError):
+        parse(filename=filename, with_tree=False, only_header=True, with_header=True)
+
+@pytest.mark.parametrize("filename", [
+    'fixtures/fail_duplicate_id.ifc',
+    'fixtures/fail_double_comma.ifc',
+    'fixtures/fail_double_semi.ifc'
+])
+def test_valid_headers(filename):
+    # error in body; with_header should not raise an error
+    with nullcontext():
+        parse(filename=filename, with_tree=False, only_header=True, with_header=True)
+        
+
+@pytest.mark.parametrize("filename", [
+    'fixtures/fail_invalid_header_entity.ifc',
+    'fixtures/fail_no_header.ifc',
+])
+def test_invalid_headers_(filename):
+    # error in header; validate_data_only should not raise an error
+    with nullcontext():
+        parse(filename=filename, validate_data_only=True)
+
+@pytest.mark.parametrize("filename", [
+    'fixtures/fail_duplicate_id.ifc',
+    'fixtures/fail_double_comma.ifc',
+    'fixtures/fail_double_semi.ifc'
+])
+def test_valid_headers(filename):
+    # error in body; validate_data_only should raise an error
+    with pytest.raises(ValidationError):
+        parse(filename=filename, validate_data_only=True)


### PR DESCRIPTION
Small addition allowing us to split syntax task into `syntax_validation_header` and `syntax_validation_data`